### PR TITLE
tasks: don't fail the record is already setup

### DIFF
--- a/tasks/add.record.yml
+++ b/tasks/add.record.yml
@@ -72,3 +72,5 @@
     headers:
       Authorization: '{{ authorization }}'
       Accept: 'application/json'
+  register: patch_record
+  failed_when: patch_record.status != 200 and (patch_record.status == 422 and patch_record.json.code != "DUPLICATE_RECORD")


### PR DESCRIPTION
The godaddy api returns a 422 status code with the following body
if the record is already configured:

  status: 422
  json:
    code: DUPLICATE_RECORD
    errors:
    - Record conflicts with the existing zone records.
    fields:
    - code: DUPLICATE_RECORD
      message: A record name [your-record-name] conflicts with another record.
      path: records
    message: Another record with the same attributes already exists